### PR TITLE
Version updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,16 +27,16 @@
         <java.min.version>1.8</java.min.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Plugin versioning -->
-        <embedded-payara-maven-plugin.version>1.0.0</embedded-payara-maven-plugin.version>
-        <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
-        <payara-micro-maven-plugin.version>0.0.1</payara-micro-maven-plugin.version>
+        <embedded-payara-maven-plugin.version>1.0.1</embedded-payara-maven-plugin.version>
+        <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
+        <payara-micro-maven-plugin.version>1.0.0</payara-micro-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.pac4j.version>2.1.0</dependency.pac4j.version>
         <dependency.j2e-pac4j.version>3.0.0</dependency.j2e-pac4j.version>
         <dependency.javaee.version>7.0</dependency.javaee.version>
-        <dependency.logback.version>1.1.3</dependency.logback.version>
-        <dependency.payara-embedded-all.version>4.1.1.171.1</dependency.payara-embedded-all.version>
-        <dependency.payara-micro.version>4.1.1.171</dependency.payara-micro.version>
+        <dependency.logback.version>1.2.3</dependency.logback.version>
+        <dependency.payara-embedded-all.version>4.1.2.173.0.1</dependency.payara-embedded-all.version>
+        <dependency.payara-micro.version>4.1.2.173</dependency.payara-micro.version>
     </properties>
 
     <dependencies>
@@ -169,7 +169,7 @@
                 </dependencies>
             </plugin>
             <plugin>
-                <groupId>co.luminositylabs.oss.maven.plugins</groupId>
+                <groupId>fish.payara.maven.plugins</groupId>
                 <artifactId>payara-micro-maven-plugin</artifactId>
                 <version>${payara-micro-maven-plugin.version}</version>
                 <executions>


### PR DESCRIPTION
- Update payara-embedded-all 4.1.1.171.1 to v4.1.2.173.0.1
- Update embedded-payara-maven-plugin from v1.0.0 to v1.0.1
- Update payara-micro from v4.1.1.171 to v4.1.2.173
- Switch payara-micro-maven-plugin from luminositylabs to payara official
- Update maven compiler plugin from v3.6.1 to v3.7.0
- Update logback from v1.1.3 to v1.2.3